### PR TITLE
replace territory name content "CI"  with correct name

### DIFF
--- a/main/zh-Hant/territories.json
+++ b/main/zh-Hant/territories.json
@@ -89,7 +89,7 @@
           "CG-alt-variant": "剛果共和國",
           "CH": "瑞士",
           "CI": "象牙海岸",
-          "CI-alt-variant": "CI",
+          "CI-alt-variant": "象牙海岸",
           "CK": "庫克群島",
           "CL": "智利",
           "CM": "喀麥隆",


### PR DESCRIPTION
from
           "CI": "象牙海岸",
          "CI-alt-variant": "CI",
to
           "CI": "象牙海岸",
          "CI-alt-variant": "象牙海岸",